### PR TITLE
use LANG environment when exec dpkg-reconfigure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,5 @@
 # handlers file for locale
 - name: generate locales
   command: dpkg-reconfigure --frontend noninteractive locales
+  environment:
+    lang: locale_lang


### PR DESCRIPTION
otherwise LANG env is commented out by locales scripts.
