### PR TITLE
Remove deprecated variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,6 @@
   notify: generate locales
   when: ansible_os_family == "Debian"
 
-- name: set locale to $locale
+- name: set locale to {{ locale }}
   template: src=default.j2 dest=/etc/default/locale
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
It's for remove this message : 
 [DEPRECATION WARNING]: Legacy variable substitution, such as using ${foo} or
$foo instead of {{ foo }} is currently valid but will be phased out and has
been out of favor since version 1.2. This is the last of legacy features on our
deprecation list. You may continue to use this if you have specific needs for
now. This feature will be removed in version 1.6. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
