### PR TITLE
Show defined locale in ansible output

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
   locale_gen: name={{locale_lang}} state=present
   when: ansible_os_family == "Debian"
 
-- name: set locale to {{ locale }}
+- name: set locale
   template: src=default.j2 dest=/etc/default/locale
   when: ansible_os_family == "Debian"
+  with_items:
+    - "{{locale_lang}}"


### PR DESCRIPTION
Thanks for the role! Working nice for me.

Since template variables are not allowed in tasks names, i suggest to use `with_items:` to  visualise defined locale and avoid output like:

```
TASK: [knopki.ansible-locale | set locale to {{ locale }}] ********************
```